### PR TITLE
feat(claude): disable co-authored-by in git commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,5 +74,6 @@
                 ]
             }
         ]
-    }
+    },
+    "includeCoAuthoredBy": false
 }


### PR DESCRIPTION
Add includeCoAuthoredBy configuration option set to false to prevent Claude from automatically adding co-authored-by trailers to git commit messages.