### PR TITLE
feat(zsh): add git worktree management functions

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -11,3 +11,96 @@ eval "$(rbenv init -)"
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# git worktreeで新しいブランチを作成し、そのディレクトリに移動する
+gwt() {
+  local branch_name="$1"
+  local repo_root
+  local worktree_base
+  local worktree_path
+
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -z "$repo_root" ]]; then
+    echo "Error: Not in a git repository" >&2
+    return 1
+  fi
+
+  # ブランチ名が指定されていない場合は自動生成
+  if [[ -z "$branch_name" ]]; then
+    branch_name="wt-$(date +%Y%m%d-%H%M%S)"
+  fi
+
+  # VSCodeと同じ形式: リポジトリ名.worktrees/ブランチ名
+  worktree_base="${repo_root}.worktrees"
+  worktree_path="${worktree_base}/${branch_name}"
+
+  # worktreesディレクトリがなければ作成
+  mkdir -p "$worktree_base"
+
+  # worktreeを作成
+  if git worktree add -b "$branch_name" "$worktree_path" 2>/dev/null; then
+    echo "Created worktree at: $worktree_path"
+    echo "Branch: $branch_name"
+    cd "$worktree_path"
+  elif git worktree add "$worktree_path" "$branch_name" 2>/dev/null; then
+    # 既存のブランチを使用する場合
+    echo "Created worktree at: $worktree_path"
+    echo "Branch: $branch_name (existing)"
+    cd "$worktree_path"
+  else
+    echo "Error: Failed to create worktree" >&2
+    return 1
+  fi
+}
+
+# マージ済みブランチのworktreeを削除する
+gwt-clean() {
+  local repo_root
+  local main_branch
+  local worktree_path
+  local branch_name
+  local deleted_count=0
+
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -z "$repo_root" ]]; then
+    echo "Error: Not in a git repository" >&2
+    return 1
+  fi
+
+  # メインブランチを特定（main or master）
+  if git show-ref --verify --quiet refs/heads/main; then
+    main_branch="main"
+  elif git show-ref --verify --quiet refs/heads/master; then
+    main_branch="master"
+  else
+    echo "Error: Could not find main or master branch" >&2
+    return 1
+  fi
+
+  # リモートの最新情報を取得
+  git fetch --prune 2>/dev/null
+
+  # worktree一覧を取得して処理
+  git worktree list --porcelain | while read -r line; do
+    if [[ "$line" == worktree\ * ]]; then
+      worktree_path="${line#worktree }"
+    elif [[ "$line" == branch\ * ]]; then
+      branch_name="${line#branch refs/heads/}"
+
+      # メインブランチ自体はスキップ
+      if [[ "$branch_name" == "$main_branch" ]]; then
+        continue
+      fi
+
+      # メインブランチにマージ済みか確認
+      if git branch --merged "$main_branch" | grep -q "^\s*${branch_name}$"; then
+        echo "Removing: $worktree_path (branch: $branch_name)"
+        git worktree remove "$worktree_path" 2>/dev/null
+        git branch -d "$branch_name" 2>/dev/null
+        ((deleted_count++))
+      fi
+    fi
+  done
+
+  echo "Done. Removed $deleted_count worktree(s)."
+}


### PR DESCRIPTION
## 概要
git worktree管理用のシェル関数を追加

## 変更内容
### `gwt` - worktree作成コマンド
- 新しいブランチでworktreeを作成し、そのディレクトリに移動
- ブランチ名は引数で指定可能、省略時は `wt-YYYYMMDD-HHMMSS` 形式で自動生成
- VSCodeと同じパス形式（`リポジトリ名.worktrees/ブランチ名`）を使用

```bash
gwt feature/my-branch    # ブランチ名指定
gwt                      # 自動生成
```

### `gwt-clean` - マージ済みworktree削除コマンド
- main/masterにマージ済みのブランチを持つworktreeを検出して削除
- ブランチも同時に削除

```bash
gwt-clean
```

## 変更ファイル
- `.zshrc`: 2つのシェル関数を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - New shell helper for streamlined Git worktree creation with automatic path management
  - New shell utility to automatically identify and remove merged worktrees, reducing manual cleanup tasks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->