### PR TITLE
fix(settings): remove trailing comma in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,7 @@
       "Bash(mkdir:*)",
       "Bash(mv:*)",
       "Bash(tail:*)",
-      "Bash(jq:*)",
+      "Bash(jq:*)"
     ]
   },
   "feedbackSurveyState": {


### PR DESCRIPTION
## Summary
- settings.jsonの`permissions.allow`配列の最後の要素の後にある末尾カンマを削除
- これによりJSONパースエラーが解消され、Claude Codeが設定ファイルを正常に読み込めるようになる

## Changes
- `.claude/settings.json`: `"Bash(jq:*)",` → `"Bash(jq:*)"` 

## Test plan
- [ ] Claude Codeを再起動して設定が正常に読み込まれることを確認