### PR TITLE
fix(gitconfig): prevent delete-mb from removing worktree branches

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -4,5 +4,15 @@
 [core]
         editor = code --wait
 [alias]
-        # delete merged branches
-        delete-mb = "!f () { git checkout $1; git branch --merged|egrep -v '\\*|develop|main|master|production'|xargs git branch -d; };f"
+	# delete merged branches
+	delete-mb = "!f() { \
+	  base=${1:-main}; \
+	  git checkout \"$base\" || exit 1; \
+	  used=$(git worktree list --porcelain | awk '/branch /{print $2}' | sed 's#refs/heads/##'); \
+	  git branch --merged \"$base\" --format='%(refname:short)' \
+	    | grep -Ev '^(develop|main|master|production)$' \
+	    | while read b; do \
+	        echo \"$used\" | grep -qx \"$b\" && continue; \
+	        git branch -d \"$b\"; \
+	      done; \
+	}; f"


### PR DESCRIPTION
## Summary
- worktreeで使用中のブランチを削除対象から除外するよう`delete-mb`エイリアスを改良
- 引数なしの場合、デフォルトのベースブランチを`main`に設定
- エラーハンドリングを追加してスクリプトの堅牢性を向上

## Test plan
- [ ] `git worktree`でブランチを使用中に`git delete-mb`を実行し、使用中のブランチが削除されないことを確認
- [ ] 引数なしで実行時に`main`ブランチがデフォルトで使用されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Enhanced the branch deletion git command with improved error handling during branch checkouts, expanded protection filtering for critical branches, and added support for git worktree environments to prevent accidental deletion of branches currently in use across your development setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->