### PR TITLE
fix(commands): clarify pr-fix fallback to current branch PR

### DIFF
--- a/commands/pr-fix.md
+++ b/commands/pr-fix.md
@@ -17,7 +17,7 @@ PR番号省略時は現在のブランチのPRを使用。
 - lint/type/test/build エラーを自動修正
 
 ## 手順
-1. `gh pr view` でPR情報取得
+1. PR番号が指定されていない場合は `gh pr view` (引数なし)で現在のブランチのPRを取得。指定されている場合は `gh pr view <番号>` でPR情報取得
 2. `gh api pulls/:pr/comments` でレビューコメント取得
 3. コンフリクト確認、あれば解消
 4. `gh pr checks` でCIエラー確認


### PR DESCRIPTION
## Summary
- pr-fixコマンドの手順1で、PR番号省略時に `gh pr view`（引数なし）で現在のブランチのPRを取得する動作を明確化

## Test plan
- [ ] `/pr-fix` を番号なしで実行し、現在のブランチのPRが取得されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR-fix workflow to support flexible PR specification: now automatically uses the current branch's PR when no number is provided, or accepts an explicit PR number when specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->