### PR TITLE
feat(permissions): allow all Playwright MCP tools automatically

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,7 +29,8 @@
       "Bash(mkdir:*)",
       "Bash(mv:*)",
       "Bash(tail:*)",
-      "Bash(jq:*)"
+      "Bash(jq:*)",
+      "mcp__playwright__*"
     ]
   },
   "feedbackSurveyState": {


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の `permissions.allow` に `mcp__playwright__*` を追加
- Playwright MCP の全ツール（browser_click, browser_snapshot, browser_navigate 等）を確認なしで自動許可

## Test plan
- [ ] Claude Code で Playwright MCP ツール使用時にプロンプトが表示されないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permission configurations to support additional integration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->