### PR TITLE
fix(zshrc): update hashicorp plugin identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 history.jsonl
 .claude/file-history
 .claude/debug
+.claude/plans

--- a/.zshrc
+++ b/.zshrc
@@ -161,5 +161,56 @@ export EDITOR="code-insiders"
 alias cc='claude'
 alias ccw='claude --worktree'
 alias ccu='brew upgrade claude-code'
-alias ccpi='claude plugin marketplace add ~/src/dotfiles && claude plugin install doarakko-config@doarakko-config && claude plugin marketplace add hashicorp/agent-skills && claude plugin install terraform-code-generation@hashicorp && claude plugin install terraform-module-generation@hashicorp && claude plugin marketplace add anthropics/skills && claude plugin install example-skills@anthropic-agent-skills && claude plugin marketplace add anthropics/claude-plugins-official && claude plugin install claude-md-management@claude-plugins-official && claude plugin install gopls-lsp@claude-plugins-official && claude plugin install typescript-lsp@claude-plugins-official && claude plugin install pyright-lsp@claude-plugins-official && claude plugin install feature-dev@claude-plugins-official'
-alias ccpu='claude plugin marketplace update && claude plugin uninstall doarakko-config@doarakko-config; claude plugin install doarakko-config@doarakko-config && claude plugin uninstall terraform-code-generation@hashicorp; claude plugin install terraform-code-generation@hashicorp && claude plugin uninstall terraform-module-generation@hashicorp; claude plugin install terraform-module-generation@hashicorp && claude plugin uninstall example-skills@anthropic-agent-skills; claude plugin install example-skills@anthropic-agent-skills && claude plugin uninstall claude-md-management@claude-plugins-official; claude plugin install claude-md-management@claude-plugins-official && claude plugin uninstall feature-dev@claude-plugins-official; claude plugin install feature-dev@claude-plugins-official'
+
+# 登録するマーケットプレイス（ccpi/ccpuで共有）
+CLAUDE_MARKETPLACES=(
+  ~/src/dotfiles
+  hashicorp/agent-skills
+  anthropics/skills
+  anthropics/claude-plugins-official
+)
+
+# インストールするプラグイン（ccpi/ccpuで共有）
+CLAUDE_PLUGINS=(
+  doarakko-config@doarakko-config
+  terraform-code-generation@hashicorp
+  terraform-module-generation@hashicorp
+  example-skills@anthropic-agent-skills
+  context7@claude-plugins-official
+  claude-md-management@claude-plugins-official
+  gopls-lsp@claude-plugins-official
+  typescript-lsp@claude-plugins-official
+  pyright-lsp@claude-plugins-official
+  feature-dev@claude-plugins-official
+)
+
+# マーケットプレイスを登録する（登録済みの場合は何もしない）
+cc-marketplace-add() {
+  local marketplace
+  for marketplace in "${CLAUDE_MARKETPLACES[@]}"; do
+    claude plugin marketplace add "$marketplace" || return 1
+  done
+}
+
+# プラグインをインストールする
+ccpi() {
+  cc-marketplace-add || return 1
+
+  local plugin
+  for plugin in "${CLAUDE_PLUGINS[@]}"; do
+    claude plugin install "$plugin"
+  done
+}
+
+# プラグインを再インストールして最新化する
+ccpu() {
+  # マーケットプレイス未登録だとinstallが失敗するため先に登録する
+  cc-marketplace-add || return 1
+  claude plugin marketplace update
+
+  local plugin
+  for plugin in "${CLAUDE_PLUGINS[@]}"; do
+    claude plugin uninstall "$plugin"
+    claude plugin install "$plugin"
+  done
+}

--- a/.zshrc
+++ b/.zshrc
@@ -173,8 +173,8 @@ CLAUDE_MARKETPLACES=(
 # インストールするプラグイン（ccpi/ccpuで共有）
 CLAUDE_PLUGINS=(
   doarakko-config@doarakko-config
-  terraform-code-generation@hashicorp
-  terraform-module-generation@hashicorp
+  terraform@hashicorp
+  packer@hashicorp
   example-skills@anthropic-agent-skills
   context7@claude-plugins-official
   claude-md-management@claude-plugins-official

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ git clone https://github.com/Doarakko/dotfiles.git
 
 Add `source ~/src/dotfiles/.zshrc` to your `~/.zshrc` to load the configuration.
 
+Keep `~/.zshrc` limited to machine-specific settings (PATH entries, version managers, tool shell integrations) plus that one `source` line. Never copy the contents of this repository's `.zshrc` into `~/.zshrc` — the copy goes stale and changes made here stop taking effect.
+
 ### Claude Code
 
 install

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ Add `source ~/src/dotfiles/.zshrc` to your `~/.zshrc` to load the configuration.
 install
 
 ```bash
-claude-plugin-install
+ccpi
 ```
 
 update
 
 ```bash
-claude-plugin-update
+ccpu
 ```
+
+Both register the marketplaces listed in `CLAUDE_MARKETPLACES` first, then process every plugin in `CLAUDE_PLUGINS` (defined in `.zshrc`). Add or remove plugins in those arrays only — `ccpi` and `ccpu` share them.
 
 After install/update, restart Claude Code to apply changes.
 


### PR DESCRIPTION
## 背景

`ccpi` / `ccpu` が HashiCorp のプラグインインストールに失敗していた。

```
✘ Failed to install plugin "terraform-code-generation@hashicorp": Plugin "terraform-code-generation" not found in marketplace "hashicorp".
```

`hashicorp/agent-skills` が製品単位のバンドルに再編され、旧プラグイン識別子が削除されたため。CHANGELOG (Unreleased) に記載がある。

> **Removed**: The `terraform-code-generation`, `terraform-module-generation`, `terraform-provider-development`, `terraform-policy-code`, `packer-builders`, and `packer-hcp` Plugin identifiers and manifests.

現在のマニフェストに存在するのは `terraform` と `packer` の2つのみ。

## 変更内容

- `CLAUDE_PLUGINS` の `terraform-code-generation@hashicorp` / `terraform-module-generation@hashicorp` を `terraform@hashicorp` に置き換え
  - 旧2プラグインの全スキル（configuration, modules, providers, tests, imports, stacks, policy）が `terraform` バンドルに含まれるため機能の欠落はない
- `packer@hashicorp` を追加
- README に「`~/.zshrc` へ本リポジトリの `.zshrc` をコピーしない」旨の注意書きを追加
  - コピーされた `~/.zshrc` が陳腐化し、本リポジトリへの変更が反映されなくなる事象が実際に発生したため

## 確認

- `hashicorp/agent-skills` の `.claude-plugin/marketplace.json` を参照し、`terraform` / `packer` が存在することを確認済み